### PR TITLE
fix(@pvm/vcs): make platform packages optional

### DIFF
--- a/packages/pvm-vcs/package.json
+++ b/packages/pvm-vcs/package.json
@@ -10,11 +10,21 @@
     "@pvm/core": "0.0.0-stub",
     "@pvm/cowners": "0.0.0-stub",
     "@pvm/vcs-git": "0.0.0-stub",
-    "@pvm/gitlab": "0.0.0-stub",
-    "@pvm/github": "0.0.0-stub",
     "@pvm/vcs-fs": "0.0.0-stub",
     "hosted-git-info": "^3.0.2",
     "resolve-from": "^5.0.0",
     "string-to-color": "^2.2.2"
+  },
+  "peerDependencies": {
+    "@pvm/gitlab": "0.0.0-stub",
+    "@pvm/github": "0.0.0-stub"
+  },
+  "peerDependenciesMeta": {
+    "@pvm/gitlab": {
+      "optional": true
+    },
+    "@pvm/github": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This will breaks current usages when only @pvm/pvm needed for work. Now you also will be need a @pvm/github or @pvm/gitlab package to be specified in depedencies of your project