### PR TITLE
fix(@pvm/mattermost): incoming webhooks support added

### DIFF
--- a/packages/pvm-core/env-schema.json
+++ b/packages/pvm-core/env-schema.json
@@ -161,6 +161,10 @@
             "description": "Logging level",
             "type": "string"
         },
+        "PVM_MATTERMOST_INCOMING_WEBHOOK": {
+            "description": "Optional incoming webhook. https://docs.mattermost.com/developer/webhooks-incoming.html.\nIt will be used prior to token if specified",
+            "type": "string"
+        },
         "PVM_MATTERMOST_TEAM": {
             "description": "If provided than mattermost client will try first to get channel id from team and passed channel and, if failed,\nthen try to use channel as channel_id.",
             "type": "string"

--- a/packages/pvm-core/env-schema.ts
+++ b/packages/pvm-core/env-schema.ts
@@ -50,6 +50,11 @@ export interface Env {
    */
   PVM_MATTERMOST_URL?: string,
   /**
+   * Optional incoming webhook. https://docs.mattermost.com/developer/webhooks-incoming.html.
+   * It will be used prior to token if specified
+   */
+  PVM_MATTERMOST_INCOMING_WEBHOOK?: string,
+  /**
    * Flag that script running in continuous integration environment
    */
   CI?: 'true' | 'false',

--- a/packages/pvm-mattermost/README.md
+++ b/packages/pvm-mattermost/README.md
@@ -1,8 +1,14 @@
 # @pvm/mattermost
 
-Предоставляет клиент для мессенджера `mattermost`. Клиент реализует интерфейс [AbstractMessengerClient](api/classes/pvm_notifications.AbstractMessengerClient.md).
+A client for  `mattermost` messenger. Client implementing [AbstractMessengerClient](api/classes/pvm_notifications.AbstractMessengerClient.md).
 
-## Подключение в проекте
+## Required environment variables
+
+`PVM_MATTERMOST_TOKEN` и `PVM_MATTERMOST_URL` - for sending message via REST API
+
+`PVM_MATTERMOST_INCOMING_WEBHOOK` - for sending via [incoming webhooks](https://docs.mattermost.com/developer/webhooks-incoming.html)
+
+## Enabling in project
 
 `.pvm.toml`
 ```toml
@@ -11,5 +17,4 @@
 name = 'mattermost'
 pkg = '@pvm/mattermost'
 ```
-После этого, в зависимости от настроек [нотификаций](api/interfaces/pvm_core.Config.md#notifications), сообщения будут отправляться
-в мессенджер `mattermost`
+After that, depending on [notifications settings](api/interfaces/pvm_core.Config.md#notifications), messages will be sending to `mattermost` messenger

--- a/packages/pvm-notifications/cli/commands/pvm-notification-send.ts
+++ b/packages/pvm-notifications/cli/commands/pvm-notification-send.ts
@@ -21,7 +21,7 @@ export const builder = (yargs: Argv) => {
     })
     .option('file', {
       alias: 'f',
-      desc: 'message json file',
+      desc: 'message json file. Available fields described in doc https://tinkoff.github.io/pvm/docs/api/modules/pvm_types#message',
     })
     .option('channel', {
       alias: 'c',

--- a/packages/pvm-notifications/lib/notificator.ts
+++ b/packages/pvm-notifications/lib/notificator.ts
@@ -77,7 +77,7 @@ export class Notificator {
         }
     }
     if (errors.length) {
-      throw new Error(`Message sent is finished with errors:\n${errors.map(e => e.message).join('\n')}`)
+      throw new Error(`Message sent is finished with errors:\n${errors.map(e => `${e.message}\n${e.stack}`).join('\n')}`)
     }
   }
 }


### PR DESCRIPTION
Specify PVM_MATTERMOST_INCOMING_WEBHOOK env variable to send messages via incoming webhooks

Useful links:
https://tinkoff.github.io/pvm/docs/api/modules/pvm_mattermost
https://docs.mattermost.com/developer/webhooks-incoming.html