### PR TITLE
fix(@pvm/core): add peerDependencies and optionalDependencies as default deps_keys

### DIFF
--- a/packages/pvm-core/pvm-defaults.ts
+++ b/packages/pvm-core/pvm-defaults.ts
@@ -59,6 +59,8 @@ export const defaultConfig: Config = {
     deps_keys: [
       'dependencies',
       'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
     ],
   },
   release_list: {


### PR DESCRIPTION
This fix error when stub version in peerDependencies is not replaced with actual one