### PR TITLE
fix(@pvm/update): update_dependants now matches by pkg path

### DIFF
--- a/packages/pvm-core/config-schema.json
+++ b/packages/pvm-core/config-schema.json
@@ -860,7 +860,7 @@
                             "items": {
                                 "properties": {
                                     "match": {
-                                        "description": "Glob pattern for matching package. Match checked against package name only.",
+                                        "description": "Packages [universal selector]([universal selector](/book/glossary.md)",
                                         "type": "string"
                                     },
                                     "release_type": {
@@ -869,6 +869,7 @@
                                             "as-dep",
                                             "major",
                                             "minor",
+                                            "none",
                                             "patch"
                                         ],
                                         "type": "string"
@@ -882,7 +883,7 @@
                             "type": "boolean"
                         }
                     ],
-                    "description": "Update dependant packages of changed. If provided list of globs then only for those who match these globs will dependants be updated"
+                    "description": "Update dependant packages of changed. If provided list of objects with `match` property where `match` is [universal selector](/book/glossary.md) then only for those who match these selectors will dependants be updated"
                 },
                 "workspace_release_files": {
                     "description": "Use special release files, that are force semver release type of package. If disabled, than these files are ignored.",

--- a/packages/pvm-core/config-schema.ts
+++ b/packages/pvm-core/config-schema.ts
@@ -282,17 +282,17 @@ export interface Config {
      */
     include_uncommited: boolean,
     /**
-     * Update dependant packages of changed. If provided list of globs then only for those who match these globs will dependants be updated
+     * Update dependant packages of changed. If provided list of objects with `match` property where `match` is [universal selector](/book/glossary.md) then only for those who match these selectors will dependants be updated
      */
     update_dependants: boolean | Array<{
       /**
-       * Glob pattern for matching package. Match checked against package name only.
+       * Packages [universal selector]([universal selector](/book/glossary.md)
        */
       match: GlobPattern,
       /**
        * Dependant release type. If not set then update.dependants_release_type is used. 'as-dep' means use same version as in changed dependency.
        */
-      release_type: SemverReleaseType | 'as-dep',
+      release_type: SemverReleaseType | 'as-dep' | 'none',
     }>,
     /**
      * Git ref for changed calculations when no previous release exists. Or false if pvm should calculate it by itself.

--- a/packages/pvm-core/lib/pkg-match.ts
+++ b/packages/pvm-core/lib/pkg-match.ts
@@ -12,7 +12,7 @@ export function matchPackage(pkg: Pkg, pattern: string): boolean {
   })
 }
 
-export function matchAny(pkg: Pkg, patterns: string[]): boolean {
+export function matchAny(pkg: Pkg, patterns: string[] | readonly string[]): boolean {
   for (const pattern of patterns) {
     if (matchPackage(pkg, pattern)) {
       return true

--- a/packages/pvm-update/lib/dependants-updater.ts
+++ b/packages/pvm-update/lib/dependants-updater.ts
@@ -1,6 +1,5 @@
-import micromatch from 'micromatch'
 import semver from 'semver'
-import { matchGroup } from '@pvm/core/lib/pkg-match'
+import { matchAny, matchGroup } from '@pvm/core/lib/pkg-match'
 import sortByRelease from '@pvm/core/lib/packages/sort-by-release'
 import { loggerFor } from '@pvm/core/lib/logger'
 import { releaseTypes as releaseTypesMath } from '@pvm/core/lib/semver-extra'
@@ -13,10 +12,6 @@ import type { UpdateState } from './update-state'
 import { decreaseReleaseTypeForPackagesWithZeroMajorVersion } from './pkg-release-type'
 
 const logger = loggerFor('pvm:dependants-updater')
-
-const matchOpts = {
-  matchBase: true,
-}
 
 export async function processAffectedByDependants(repo: Repository, updateState: UpdateState, targetPackages: Iterable<Pkg>): Promise<Pkg[]> {
   const dependantsTree = repo.dependantsTree
@@ -81,7 +76,7 @@ export async function processAffectedByDependants(repo: Repository, updateState:
 
       const patterns: ReadonlyArray<string> = typeof matchExpr === 'string' ? [matchExpr] : matchExpr
 
-      if (micromatch.any(pkg.name, patterns, matchOpts)) {
+      if (matchAny(pkg, patterns)) {
         const hostReleaseType: SemverReleaseType | null = updateState.getLikelyReleaseTypeFor(pkg)
         if (releaseType === 'as-dep') {
           // если версия не менялась releaseType будет null


### PR DESCRIPTION
In addition to pkg name matching `update_dependants[].match` now matching pkg path also (see https://tinkoff.github.io/pvm/docs/book/glossary#%D1%81%D0%B5%D0%BB%D0%B5%D0%BA%D1%82%D0%BE%D1%80-%D0%BF%D0%B0%D0%BA%D0%B5%D1%82%D0%BE%D0%B2)