### PR TITLE
fix(@pvm/plugin-core): add unified canary version calculation option

### DIFF
--- a/src/plugins/core/publish/flags.ts
+++ b/src/plugins/core/publish/flags.ts
@@ -12,6 +12,16 @@ const canaryFlag = {
       'preid suffix from parametes (example: 1.0.1-12ax3f.0). Also in canary mode "strategy" parameter changes it`s default value to "affected"',
     default: false,
   },
+  'canary-unified': {
+    type: 'boolean' as const,
+    desc: 'If true then all packages in canary release will have same version.',
+    default: false,
+  },
+  'canary-base-version': {
+    type: 'string' as const,
+    desc: 'Base for canary version if unified set to true. For example if base_version = "0.0.0", then canary version will be (by default) "0.0.0-<commit sha>.0"',
+    default: '0.0.0',
+  },
 }
 
 const messageChannelFlag = {

--- a/src/plugins/core/publish/index.ts
+++ b/src/plugins/core/publish/index.ts
@@ -110,6 +110,8 @@ export async function publish(flags: Flags): Promise<PublishedStats> {
   const publishApplier = flags.canary ? new CanaryPublishApplier(repo, new PkgSet(packagesForPublish), flags)
     : new BasicPublishApplier(repo)
 
+  await publishApplier.prepare()
+
   if (flags.byDependentOrder) {
     const dependentPackagesList: Pkg[][] = []
     const tree = buildDependantPackagesListIntoTree(packagesForPublish)

--- a/src/plugins/core/publish/publish-applier/abstract.ts
+++ b/src/plugins/core/publish/publish-applier/abstract.ts
@@ -16,6 +16,10 @@ export abstract class AbstractPublishApplier {
 
   abstract getPkgPublishVersion(pkg: Pkg): Promise<string>;
 
+  async prepare(): Promise<void> {
+    return Promise.resolve()
+  }
+
   async applyActualDeps(pkg: Pkg): Promise<AppliedPkg> {
     const deps = pkg.deps
     const newDeps: Map<string, string> = new Map()


### PR DESCRIPTION
New publish command flags
- canary-unified
- canary-base-version