### PR TITLE
remove ability to provide plugins in constructor

### DIFF
--- a/packages/pvm/app/__tests__/__fixtures__/plugin-with-options.js
+++ b/packages/pvm/app/__tests__/__fixtures__/plugin-with-options.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { declarePlugin, provide } = require('@pvm/pvm')
+
+module.exports = declarePlugin({
+  factory(opts) {
+    return {
+      providers: [
+        provide({
+          provide: 'TEST_TOKEN',
+          useValue: opts.value,
+        }),
+      ],
+    }
+  },
+})


### PR DESCRIPTION
replaced with getDefaultConfig protected method in Pvm class. I dont want to give user ability to override plugins in config when using node api. Config in repo should define pvm behaviour in all cases (cli and node). Envs is exception