### PR TITLE
Use builtin.list-with-packages default for changelogs

### DIFF
--- a/packages/pvm-core/pvm-defaults.ts
+++ b/packages/pvm-core/pvm-defaults.ts
@@ -82,7 +82,7 @@ export const defaultConfig: ConfigSchema = {
     },
     skip_empty: false,
     renderer: {
-      type: 'builtin.list',
+      type: 'builtin.list-with-packages',
       tag_head_level: 2,
       show_date: true,
     },


### PR DESCRIPTION
Он намного информативней в случае монореп. Что превышает возможные неудобства в синглерепе, которых меньшиство по сути